### PR TITLE
Update valid_move_spec.rb

### DIFF
--- a/spec/valid_move_spec.rb
+++ b/spec/valid_move_spec.rb
@@ -10,7 +10,7 @@ describe './lib/valid_move.rb' do
   end
 
   it 'returns nil or false for an occupied position' do
-    board = [" ", " ", " ", " ", "X", " ", " ", " ", " "]
+    board = [" ", " ", " ", " ", " ", "X", " ", " ", " "]
     position = "5"
     
     expect(valid_move?(board, position)).to be_falsey


### PR DESCRIPTION
The second test in the spec was returning true but expects a false value. This is due to the `X` being in `position 4` and not `position 5` as intended. Arrays start at `index 0`. I have fixed the spec by moving the `X` one position to the right.
